### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/verify-workflow.yaml
+++ b/.github/workflows/verify-workflow.yaml
@@ -87,10 +87,10 @@ jobs:
           fi
           
           echo "Repo: ${REPO}"
-          echo "::set-output name=infra-repo::$REPO"
+          echo "infra-repo=$REPO" >> "$GITHUB_OUTPUT"
           
           echo "Repo branch: ${REPO_BRANCH}"
-          echo "::set-output name=infra-repo-branch::$REPO_BRANCH"
+          echo "infra-repo-branch=$REPO_BRANCH" >> "$GITHUB_OUTPUT"
           
           RANDOM_PREFIX=$(echo $RANDOM | md5sum | head -c 5; echo)
           FLAVOR_CHAR=$(echo "${FLAVOR}" | fold -w ${1:-1} | head -n 1)
@@ -100,7 +100,7 @@ jobs:
           NAME_PREFIX="${PROVIDER_CHAR}${FLAVOR_CHAR}${STORAGE_CHAR}-${RANDOM_PREFIX}"
           
           echo "Name prefix: $NAME_PREFIX"
-          echo "::set-output name=name-prefix::$NAME_PREFIX"
+          echo "name-prefix=$NAME_PREFIX" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter